### PR TITLE
suppress wall message due to error

### DIFF
--- a/src/ups.py
+++ b/src/ups.py
@@ -34,12 +34,12 @@ def read_status(clear_fault=False):
 
         if status["PowerInputStatus"] == "Not Connected" and disconnectflag == False :
             disconnectflag = True
-            message = "echo Power Disconnected, system will shutdown in %d minutes! | wall" % (status['TimeRemaining'])
+            message = "echo Power Disconnected, system will shutdown in %d minutes! | wall -n " % (status['TimeRemaining'])
             os.system(message)
         
         if status["PowerInputStatus"] == "Connected" and disconnectflag == True :
             disconnectflag = False
-            message = "echo Power Restored, battery at %d percent | wall" % (status['BatteryPercentage'])
+            message = "echo Power Restored, battery at %d percent | wall -n " % (status['BatteryPercentage'])
             os.system(message)
         
         if ENABLE_UDP:


### PR DESCRIPTION
The messages were not showing up due to a tty not being available. I ran the installer as root and the ups service runs as root.

`Aug 24 21:30:36 raspberrypi python[1264]: wall: cannot get tty name: Inappropriate ioctl for device`

`raspberry_pi_ups# uname -a
Linux raspberrypi 5.4.51-v7+ #1333 SMP Mon Aug 10 16:45:19 BST 2020 armv7l GNU/Linux`

`raspberry_pi_ups# cat /etc/debian_version 
10.4`

